### PR TITLE
media-dialog: Hide the revealer when possible

### DIFF
--- a/data/wb-media-dialog.ui
+++ b/data/wb-media-dialog.ui
@@ -21,9 +21,12 @@
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                         <property name="margin-start">24</property>
+                        <property name="no-show-all">TRUE</property>
                         <property name="transition-type">crossfade</property>
+                        <property name="visible">True</property>
                         <child>
                             <object class="GtkButton" id="previous_button">
+                                <property name="visible">True</property>
                                 <signal name="clicked" handler="previous_button_clicked_cb"/>
                                 <style>
                                     <class name="osd"/>
@@ -31,6 +34,7 @@
                                 <child>
                                     <object class="GtkImage">
                                         <property name="icon-name">pan-start-symbolic</property>
+                                        <property name="visible">True</property>
                                     </object>
                                 </child>
                             </object>
@@ -43,9 +47,12 @@
                         <property name="halign">end</property>
                         <property name="valign">center</property>
                         <property name="margin-end">24</property>
+                        <property name="no-show-all">TRUE</property>
                         <property name="transition-type">crossfade</property>
+                        <property name="visible">True</property>
                         <child>
                             <object class="GtkButton" id="next_button">
+                                <property name="visible">True</property>
                                 <signal name="clicked" handler="next_button_clicked_cb"/>
                                 <style>
                                     <class name="osd"/>
@@ -53,6 +60,7 @@
                                 <child>
                                     <object class="GtkImage">
                                         <property name="icon-name">pan-end-symbolic</property>
+                                        <property name="visible">True</property>
                                     </object>
                                 </child>
                             </object>

--- a/src/wb-media-dialog.c
+++ b/src/wb-media-dialog.c
@@ -137,6 +137,11 @@ change_media (WbMediaDialog *media_dialog,
 
     priv->nth_media = previous ? priv->nth_media - 1 : priv->nth_media + 1;
 
+    /* Reveal the previous and next button or not */
+    gtk_widget_set_visible (priv->previous_revealer, priv->nth_media != 1);
+    gtk_widget_set_visible (priv->next_revealer,
+                            priv->nth_media != priv->images->len);
+
     cur_image = g_array_index (priv->images, WbImageButton *, priv->nth_media - 1);
     pixbuf = wb_image_button_get_pixbuf (cur_image);
 
@@ -243,6 +248,18 @@ wb_media_dialog_new (GArray *images,
     priv->images = images;
     priv->nth_media = nth_media;
     priv->cur_image = cur_image;
+
+    /* Whether to reveal the previous and next button or not */
+    if (priv->nth_media == 1)
+    {
+        g_print ("hide previous\n");
+        gtk_widget_hide (priv->previous_revealer);
+    }
+    if (priv->nth_media == priv->images->len)
+    {
+        g_print ("hide next\n");
+        gtk_widget_hide (priv->next_revealer);
+    }
 
     return self;
 }


### PR DESCRIPTION
Hide the previous revealer when it’s the first image. Hide the next
revealer when it’s the last image. Hide both when it’s the only image.